### PR TITLE
implement the is-pending helper

### DIFF
--- a/addon/helpers/await.js
+++ b/addon/helpers/await.js
@@ -4,41 +4,132 @@ const {RSVP} = Ember;
 const {Promise} = RSVP;
 
 export default Ember.Helper.extend({
+  /**
+   * @property valueBeforeSettled
+   * @default null
+   *
+   * This is the value that gets returned synchronously as the helper's return
+   * value before the promise is settled. For example `{{async promise}}` will return
+   * null, before the promise is resolved or rejected.
+  */
+  valueBeforeSettled: null,
 
+  /**
+   * @method compute
+   * @public
+   * @param params Array a list of arguments passed to the Helper.
+   * @param hash Object a list of configuration options passed to the helper.
+   * This parameter is currently unused by Await.
+  */
   compute(params, hash) {
     const maybePromise = params[0];
 
     return this.ensureLatestPromise(maybePromise, (promise) => {
       Promise.resolve(promise).then((value) => {
-        this._value = value;
-        this.settle();
+        this.setValue(value, promise);
       }).catch(() => {
-        this.settle();
+        this.setValue(null, promise);
       });
     });
   },
 
+  /**
+   * @method ensureLatestPromise
+   * @public
+   * @param promise Promise the new promise coming
+   * @param callback Function function to be called with a wrapped promise
+   *
+   * Method to set the latest promise. This gets called by `compute` (which in
+   * turn gets called by `recompute`). If the promise being passed in is the
+   * same as before, then just return the value to `compute`. Otherwise, call
+   * the callback so the user can call `then`, `catch`, or `finally` on the
+   * promise to update the value using `setValue` later.
+  */
   ensureLatestPromise(promise, callback) {
     if (this._wasSettled && promise === this._promise) {
       return this._value;
     } else {
-      this.unsettle();
+      this._unsettle();
     }
 
     this._promise = promise;
 
     callback.call(this, Promise.resolve(this._promise));
-    return null;
+    return this.get('valueBeforeSettled');
   },
 
-  settle() {
-    this._wasSettled = true;
-    this.recompute();
+  /**
+   * @method _settle
+   * @private
+  */
+  _settle(promise) {
+    if (this.allowUpdates(promise)) {
+      this._wasSettled = true;
+      this.recompute();
+    }
   },
 
-  unsettle() {
+  /**
+   * @private
+   * @method _unsettle
+   *
+   * Resets the promise to null and calls recompute. Designed to be used
+   * when a new promise is passed to the `compute` method. This would happen
+   * when the value changes in Handlebars.
+  */
+  _unsettle() {
     this._wasSettled = false;
     this._promise = null;
     this.recompute();
+  },
+
+  /**
+   * @method setValue
+   * @public
+   * @param value Any the value to return to the helper
+   * @param promise Promise the promise the `setValue` call is coming from.
+   *
+   * `setValue` is how you should set the value to be returned to the helper
+   * in the app. It exists to prevent race conditions between promises.
+   * For example, you may have two promises:
+   *
+   * ```javascript
+   * let promise1 = new Ember.RSVP.Promise((resolve, reject) => {resolve("hello");});
+   * let promise2 = new Ember.RSVP.Promise((resolve, reject) => {(resolve("goodbye")});
+   * ```
+   *
+   * And a template:
+   *
+   * ```handlebars
+   * {{await promise}}
+   * ```
+   *
+   * If you set the value of `promise` to be `promise1` via your component,
+   * controller, or route, when the promise resolves, it will render the value
+   * of `promise1`, which is "hello".
+   *
+   * If you set the avlue of `promise` to `promise2`, you would see "goodbye".
+   *
+   * But what happens if `promise1` resolves asynchronously, e.g., using `Ember.run.later`?
+   *
+   * ```javascript
+   * Ember.run.later(function() {
+   *  resolve("hello");
+   * }, 200);
+   * ```
+   *
+   * Even though `promise2` already resolved with "goodbye", the template would
+   * render "hello", which is not the intended behavior. So, `setValue` makes you pass
+   * the promise so the internal book-keeping can ensure the last-set promise always wins.
+  */
+  setValue(value, promise) {
+    if (this.allowUpdates(promise)) {
+      this._value = value;
+      this._settle(promise);
+    }
+  },
+
+  allowUpdates(promise) {
+    return this._promise === promise;
   }
 });

--- a/addon/helpers/is-pending.js
+++ b/addon/helpers/is-pending.js
@@ -1,13 +1,13 @@
 import AwaitHelper from 'ember-promise-helpers/helpers/await';
 
 export default AwaitHelper.extend({
+  valueBeforeSettled: true,
+
   compute(params, hash) {
     const maybePromise = params[0];
 
     return this.ensureLatestPromise(maybePromise, (promise) => {
-      promise.then(() => {
-        this.setValue(true, promise);
-      }).catch(() => {
+      promise.catch(() => {}).finally(() => {
         this.setValue(false, promise);
       });
     });

--- a/addon/helpers/is-rejected.js
+++ b/addon/helpers/is-rejected.js
@@ -6,11 +6,9 @@ export default AwaitHelper.extend({
 
     return this.ensureLatestPromise(maybePromise, (promise) => {
       promise.then(() => {
-        this._value = false;
+        this.setValue(false, promise);
       }).catch(() => {
-        this._value = true;
-      }).finally(() => {
-        this.settle();
+        this.setValue(true, promise);
       });
     });
   }

--- a/app/helpers/is-pending.js
+++ b/app/helpers/is-pending.js
@@ -1,0 +1,1 @@
+export { default, isPending } from 'ember-promise-helpers/helpers/is-pending';

--- a/tests/integration/is-fulfilled-test.js
+++ b/tests/integration/is-fulfilled-test.js
@@ -5,7 +5,7 @@ import Ember from 'ember';
 
 const {RSVP} = Ember;
 
-moduleForComponent('integration - is-pending helper', {
+moduleForComponent('integration - is-fulfilled helper', {
   integration: true,
 
   beforeEach() {

--- a/tests/integration/is-pending-test.js
+++ b/tests/integration/is-pending-test.js
@@ -1,5 +1,5 @@
-import { moduleForComponent } from 'ember-qunit';
-import { skip } from 'qunit';
+import { test, moduleForComponent } from 'ember-qunit';
+import afterRender from 'dummy/tests/helpers/after-render';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
@@ -9,7 +9,7 @@ moduleForComponent('integration - is-pending helper', {
   integration: true
 });
 
-skip('is true until the promise resolves', function (assert) {
+test('is true until the promise resolves', function (assert) {
   let deferred = RSVP.defer();
 
   this.set('promise', deferred.promise);
@@ -22,16 +22,16 @@ skip('is true until the promise resolves', function (assert) {
     {{/if}}
   `);
 
-  assert.equal(this.$().text().trim(), 'Pending!', 'is-pending is false before resolved');
+  assert.equal(this.$().text().trim(), 'Pending!', 'is-pending is true before resolved');
 
   deferred.resolve('resolved!');
 
-  return deferred.promise.then(() => {
-    assert.equal(this.$().text().trim(), 'Done!', 'is-pending is true after resolved');
+  return afterRender(deferred.promise).then(() => {
+    assert.equal(this.$().text().trim(), 'Done!', 'is-pending is false after resolved');
   });
 });
 
-skip('is true until the promise rejects', function (assert) {
+test('is true until the promise rejects', function (assert) {
   let deferred = RSVP.defer();
 
   this.set('promise', deferred.promise);
@@ -48,12 +48,12 @@ skip('is true until the promise rejects', function (assert) {
 
   deferred.reject(new Error('oh noes'));
 
-  return deferred.promise.catch(() => {
+  return afterRender(deferred.promise).then(() => {
     assert.equal(this.$().text().trim(), 'Done!', 'is-pending is true after resolved');
   });
 });
 
-skip('always renders with the last promise set', function (assert) {
+test('always renders with the last promise set', function (assert) {
   let deferred1 = RSVP.defer();
   let deferred2 = RSVP.defer();
   let deferred3 = RSVP.defer();
@@ -72,7 +72,9 @@ skip('always renders with the last promise set', function (assert) {
   this.set('promise', deferred2.promise);
   this.set('promise', deferred3.promise);
 
-  return RSVP.all([deferred1.promise, deferred2.promise, deferred3.promise]).finally(() => {
+  const promises = [deferred1, deferred2].map(d => d.promise);
+
+  return afterRender(RSVP.all(promises)).then(() => {
     assert.equal(this.$().text().trim(), 'pending', 'the last set promise is rendered last even when other promises resolve first');
   });
 


### PR DESCRIPTION
Refactored the code around handling promises a bit. Now, the last-set
promise is guaranteed to win even if previous promises set resolve
first.