### PR TITLE
Correctness and performance improvements

### DIFF
--- a/addon/helpers/await.js
+++ b/addon/helpers/await.js
@@ -21,14 +21,16 @@ export default Ember.Helper.extend({
    * @param hash Object a list of configuration options passed to the helper.
    * This parameter is currently unused by Await.
   */
-  compute(params, hash) {
-    const maybePromise = params[0];
+  compute([maybePromise], hash) {
+    if (!maybePromise || typeof maybePromise.then !== 'function') {
+      return maybePromise;
+    }
 
     return this.ensureLatestPromise(maybePromise, (promise) => {
-      Promise.resolve(promise).then((value) => {
-        this.setValue(value, promise);
+      promise.then((value) => {
+        this.setValue(value, maybePromise);
       }).catch(() => {
-        this.setValue(null, promise);
+        this.setValue(null, maybePromise);
       });
     });
   },
@@ -54,7 +56,7 @@ export default Ember.Helper.extend({
 
     this._promise = promise;
 
-    callback.call(this, Promise.resolve(this._promise));
+    callback.call(this, Promise.resolve(promise));
     return this.get('valueBeforeSettled');
   },
 
@@ -80,7 +82,6 @@ export default Ember.Helper.extend({
   _unsettle() {
     this._wasSettled = false;
     this._promise = null;
-    this.recompute();
   },
 
   /**

--- a/addon/helpers/is-fulfilled.js
+++ b/addon/helpers/is-fulfilled.js
@@ -6,9 +6,9 @@ export default AwaitHelper.extend({
 
     return this.ensureLatestPromise(maybePromise, (promise) => {
       promise.then(() => {
-        this.setValue(true, promise);
+        this.setValue(true, maybePromise);
       }).catch(() => {
-        this.setValue(false, promise);
+        this.setValue(false, maybePromise);
       });
     });
   }

--- a/addon/helpers/is-pending.js
+++ b/addon/helpers/is-pending.js
@@ -8,7 +8,7 @@ export default AwaitHelper.extend({
 
     return this.ensureLatestPromise(maybePromise, (promise) => {
       promise.catch(() => {}).finally(() => {
-        this.setValue(false, promise);
+        this.setValue(false, maybePromise);
       });
     });
   }

--- a/addon/helpers/is-rejected.js
+++ b/addon/helpers/is-rejected.js
@@ -6,9 +6,9 @@ export default AwaitHelper.extend({
 
     return this.ensureLatestPromise(maybePromise, (promise) => {
       promise.then(() => {
-        this.setValue(false, promise);
+        this.setValue(false, maybePromise);
       }).catch(() => {
-        this.setValue(true, promise);
+        this.setValue(true, maybePromise);
       });
     });
   }

--- a/addon/helpers/promise-rejected-reason.js
+++ b/addon/helpers/promise-rejected-reason.js
@@ -5,9 +5,9 @@ export default AwaitHelper.extend({
     const maybePromise = params[0];
     return this.ensureLatestPromise(maybePromise, (promise) => {
       promise.then(() => {
-        this.setValue(null, promise);
+        this.setValue(null, maybePromise);
       }).catch((reason) => {
-        this.setValue(reason, promise);
+        this.setValue(reason, maybePromise);
       });
     });
   }


### PR DESCRIPTION
This PR fixes two bugs and one performance issue.

 1. When passed a non-promise value, the `await` helper stayed unsettled forever.

 2. When passed any promise that isn't a pure RSVP.Promise, the wrapping caused by `Promise.resolve()` was causing the equality check in `allowUpdates` to fail, so the helper output would never update.

 3. The `recompute` in `_unsettle` was unnecessary and it triggered an avoidable re-render. Recompute is only needed when the output needs to change while the input is not changing. An actual "unsettle" only happens when the input promise has changed, so we're already in the middle of recomputing anyway.