### PR TITLE
helper kept awaiting if promise returned [] or null

### DIFF
--- a/addon/helpers/await.js
+++ b/addon/helpers/await.js
@@ -28,7 +28,12 @@ export default Ember.Helper.extend({
 
     return this.ensureLatestPromise(maybePromise, (promise) => {
       promise.then((value) => {
-        this.setValue(value, maybePromise);
+        if (Ember.isPresent(value)) {
+          this.setValue(value, maybePromise);
+        }
+        else {
+          this.setValue(true, maybePromise);
+        }
       }).catch(() => {
         this.setValue(null, maybePromise);
       });


### PR DESCRIPTION
If the promise returned a value like null or [] the helper kept the await state.
This can happen if a JSON API backend returns something like this:

```
{
    "data": []
}

```

With this PR, if the value is null or [], we force a true value.
All the tests are passed.
Maybe this can be seen as a hack since i force a value to obtain my expected behavior.
