### PR TITLE
Catch action for the await helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,37 @@ Or passing it to a component:
 {{twitter-timeline users=(await user.following)}}
 ```
 
+You can supply a `catch` action which will be called upon promise rejection:
+
+```handlebars
+{{#if (await model.author catch=(action 'error'))}}
+  {{get (await model.author) 'name'}}
+{{else}}
+  {{#if authorError}}
+    Error loading the author: {{authorError}}
+  {{else}}
+    No author!
+  {{/if}}
+{{/if}}
+```
+
+The component, controller or route would have the action:
+
+```javascript
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+
+  actions: {
+    error(err, promise) {
+      this.set('authorError', err.message);
+      // it could also log, redirect, etc
+    }
+  }
+
+});
+```
+
 ## is-pending
 
 Resolves with `false` if the promise resolved or rejected, otherwise

--- a/addon/helpers/await.js
+++ b/addon/helpers/await.js
@@ -18,7 +18,8 @@ export default Ember.Helper.extend({
    * @method compute
    * @public
    * @param params Array a list of arguments passed to the Helper.
-   * @param hash Object a list of configuration options passed to the helper.
+   * @param hash Object a list of configuration options passed to the helper,
+   * such as the `catch` user-supplied action to deal with rejections
    * This parameter is currently unused by Await.
   */
   compute([maybePromise], hash) {
@@ -29,7 +30,10 @@ export default Ember.Helper.extend({
     return this.ensureLatestPromise(maybePromise, (promise) => {
       promise.then((value) => {
         this.setValue(value, maybePromise);
-      }).catch(() => {
+      }).catch((err) => {
+        if (typeof hash.catch === 'function') {
+          hash.catch.call(this, err, promise);
+        }
         this.setValue(null, maybePromise);
       });
     });

--- a/tests/integration/await-test.js
+++ b/tests/integration/await-test.js
@@ -52,6 +52,23 @@ test('renders null until the promise is rejected', function (assert) {
   });
 });
 
+test('calls an error handler if a catch action is supplied', function (assert) {
+  let deferred = RSVP.defer();
+
+  this.set('promise', deferred.promise);
+
+  this.set('errorHandler', (err, promise) => {
+    assert.equal(err.message, 'oops', 'error message reveals reason for rejection');
+    assert.equal(promise, this.get('promise'), 'the promise is the original one passed for context');
+  });
+
+  this.render(hbs`
+    <span id="promise">{{await promise catch=(action errorHandler)}}</span>
+  `);
+
+  deferred.reject(new Error('oops'));
+});
+
 test('changing the promise changes the eventually rendered value', function (assert) {
   let deferred1 = RSVP.defer();
   let deferred2 = RSVP.defer();


### PR DESCRIPTION
It's been said that one of the drawbacks of promise helpers is that templates are not the right place to deal with a promise rejection.  What makes more sense is for logic to be handled at a higher level (controller, component, route).

Actions are a great way of yielding back control so I implemented support for an optional `catch` action which will be triggered if the promise rejects.

The advantage is that  we can now easily set properties, display error messages, log or transition elsewhere.

I added tests and documentation, where there are usage examples.

I am not sure how it combines with the `is-rejected` et al helpers ... but they can probably happily coexist.

What do you think?
