### PR TITLE
Set repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ember-promise-helpers",
   "version": "1.0.5",
   "description": "Helpers for dealing with promises in your ember tempaltes.",
-  "repository": "",
+  "repository": "https://github.com/fivetanley/ember-promise-helpers.git",
   "keywords": [
     "ember-addon"
   ],


### PR DESCRIPTION
For whatever reason NPM isn't autodiscovering the repository URL for this anymore, so it's coming across to Ember Observer (and others) as `null`.