### PR TITLE
Await helper: Make it possible to set a value to be returned before the given promise is settled

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ Or use it by itself:
 {{await model.title}}
 ```
 
+A value before the promise settled can be set:
+
+```handlebars
+{{await model.title 'loading...'}}
+```
+
+
 ## is-pending
 
 Resolves with `false` if the promise resolved or rejected, otherwise

--- a/addon/helpers/await.js
+++ b/addon/helpers/await.js
@@ -18,14 +18,15 @@ export default class extends Helper {
   /**
    * @method compute
    * @public
-   * @param params Array a list of arguments passed to the Helper.
-   * @param hash Object a list of configuration options passed to the helper.
-   * This parameter is currently unused by Await.
+   * @param promise params[0] - The promise or value to be resolved.
+   * @param any [params[1] = null] - The default value to be used before the promise settles.
    */
-  compute([maybePromise]) {
+  compute([maybePromise, valueBeforeSettled = null]) {
     if (!maybePromise || typeof maybePromise.then !== 'function') {
       return maybePromise;
     }
+
+    this.valueBeforeSettled = valueBeforeSettled;
 
     return this.ensureLatestPromise(maybePromise, async (promise) => {
       try {

--- a/addon/helpers/await.js
+++ b/addon/helpers/await.js
@@ -22,11 +22,11 @@ export default class extends Helper {
    * @param any [params[1] = null] - The default value to be used before the promise settles.
    */
   compute([maybePromise, valueBeforeSettled = null]) {
+    this.valueBeforeSettled = valueBeforeSettled;
+    
     if (!maybePromise || typeof maybePromise.then !== 'function') {
       return maybePromise;
     }
-
-    this.valueBeforeSettled = valueBeforeSettled;
 
     return this.ensureLatestPromise(maybePromise, async (promise) => {
       try {

--- a/tests/integration/await-test.js
+++ b/tests/integration/await-test.js
@@ -56,6 +56,49 @@ module('integration - await helper', function (hooks) {
     });
   });
 
+  test('renders `valueBeforeSettled` until the promise is resolved', async function (assert) {
+    let deferred = RSVP.defer();
+
+    this.set('promise', deferred.promise);
+
+    await render(hbs`
+      <span id="promise">{{await this.promise 'loading'}}</span>
+    `);
+
+    assert.dom('#promise').exists({ count: 1 });
+    assert.dom('#promise').hasText('loading');
+
+    const text = 'yass!';
+
+    deferred.resolve(text);
+
+    return afterRender(deferred.promise).then(() => {
+      assert
+        .dom('#promise')
+        .hasText(text, 're-renders when the promise is resolved');
+    });
+  });
+
+  test('renders `valueBeforeSettled` until the promise is rejected', async function (assert) {
+    let deferred = RSVP.defer();
+
+    this.set('promise', deferred.promise);
+
+    await render(hbs`
+      <span id="promise">{{await this.promise 'loading'}}</span>
+    `);
+
+    assert.dom('#promise').hasText('loading');
+
+    deferred.reject(new Error('oops'));
+
+    return afterRender(deferred.promise).then(() => {
+      assert
+        .dom('#promise')
+        .hasText('', 'value of re-render does not reveal reason for rejection');
+    });
+  });
+
   test('changing the promise changes the eventually rendered value', async function (assert) {
     let deferred1 = RSVP.defer();
     let deferred2 = RSVP.defer();


### PR DESCRIPTION
Makes it possible to set a value to be returned until the given promise has settled

```handlebars
{{await model.title 'loading...'}}
```


I need it for a case where I want to set a property only to false when the promise resolves with false

```handlebars
readOnly={{await (get-something-with-a-api-call "foo" "bar") true}}
```